### PR TITLE
Silently fail on Draw.AttachText in ExecuteInEditMode

### DIFF
--- a/Assets/RuntimeDebugDraw.cs
+++ b/Assets/RuntimeDebugDraw.cs
@@ -665,6 +665,9 @@ namespace RuntimeDebugDraw.Internal
 
 		public void RegisterAttachText(Transform target, Func<string> strFunc, Vector3 offset, Color color, int size)
 		{
+			if(_attachTextEntries == null)
+				return;
+		
 			AttachTextEntry entry = null;
 			for (int ix = 0; ix < _attachTextEntries.Count; ix++)
 			{


### PR DESCRIPTION
Fixes some Exceptions when calling `Draw.AttachText`, etc. in a component marked with `[ExecuteInEditMode]`

See Issue #2