### PR TITLE
Fix 'Can't destroy Transform component' play error

### DIFF
--- a/Assets/RuntimeDebugDraw.cs
+++ b/Assets/RuntimeDebugDraw.cs
@@ -390,6 +390,9 @@ namespace RuntimeDebugDraw.Internal
 		{
 			CheckInitialized();
 
+#if UNITY_EDITOR && UNITY_2017_4_OR_NEWER
+			UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+#endif
 			return;
 		}
 
@@ -422,6 +425,9 @@ namespace RuntimeDebugDraw.Internal
 			_AlwaysBatch.Dispose();
 			_ZTestBatch.Dispose();
 
+#if UNITY_EDITOR && UNITY_2017_4_OR_NEWER
+			UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+#endif
 			return;
 		}
 
@@ -433,6 +439,17 @@ namespace RuntimeDebugDraw.Internal
 
 			return;
 		}
+		
+#if UNITY_EDITOR && UNITY_2017_4_OR_NEWER
+		private void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange playMode)
+		{
+			if (playMode == UnityEditor.PlayModeStateChange.ExitingPlayMode)
+			{
+				// hack to avoid 'Can't destroy Transform component' error due to parent hide flags.
+				transform.parent = null;
+			}
+		}
+#endif
 		#endregion
 
 		#region Draw Lines


### PR DESCRIPTION
(See issue #10) In 2018 Unity has problems cleaning up the `RuntimeDebugDraw` object nested inside the hidden wrapper object when exiting play mode. For some reason it complains about something trying to delete its Transform component: https://i.imgur.com/aZ6oEmF.png - there is no call stack, so this is originating in Unity's own internal code.

By un-parenting the object right before the play mode scene is cleaned up this error appears to not occur and the object is cleaned up as expected without Unity's backend for some reason trying to delete its Transform component.